### PR TITLE
Fix project scope to use .geno/ instead of geno/

### DIFF
--- a/geno_notes/cli.py
+++ b/geno_notes/cli.py
@@ -14,6 +14,8 @@ from geno_notes.config import ensure_config, read_config, write_config
 from geno_notes.indexer import reindex
 from geno_notes.paths import (
     GLOBAL_DIR,
+    PROJECT_DIRNAME,
+    PROJECT_SUBDIRNAME,
     Scope,
     ensure_structure,
     list_all_scopes,
@@ -91,10 +93,10 @@ def init(global_: bool, project_: bool):
             target = Scope("project", scope_for("project").dir)
         except RuntimeError:
             # No existing project; create one in cwd.
-            target_dir = Path.cwd() / "geno" / "geno-notes"
+            target_dir = Path.cwd() / PROJECT_DIRNAME / PROJECT_SUBDIRNAME
             target = Scope("project", target_dir)
     elif project_:
-        target_dir = Path.cwd() / "geno" / "geno-notes"
+        target_dir = Path.cwd() / PROJECT_DIRNAME / PROJECT_SUBDIRNAME
         target = Scope("project", target_dir)
     else:
         target = Scope("global", GLOBAL_DIR)

--- a/geno_notes/paths.py
+++ b/geno_notes/paths.py
@@ -2,12 +2,12 @@
 
 Two scopes coexist:
 - global:   ~/.geno/geno-notes/
-- project:  ./geno/geno-notes/  (walking up from cwd)
+- project:  ./.geno/geno-notes/  (walking up from cwd)
 
 Scope resolution order:
   1. $GENO_NOTES_SCOPE (global|project)
   2. $GENO_NOTES_DIR   (exact dir; scope read from its config.toml)
-  3. ancestor-walk for ./geno/geno-notes/ → project
+  3. ancestor-walk for ./.geno/geno-notes/ → project
   4. otherwise → global (auto-created on first use)
 """
 
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 GLOBAL_DIR = Path.home() / ".geno" / "geno-notes"
-PROJECT_DIRNAME = "geno"
+PROJECT_DIRNAME = ".geno"
 PROJECT_SUBDIRNAME = "geno-notes"
 
 
@@ -29,7 +29,7 @@ class Scope:
 
 
 def _find_project_dir(start: Path) -> Path | None:
-    """Walk up from `start` looking for ./geno/geno-notes/."""
+    """Walk up from `start` looking for ./.geno/geno-notes/."""
     cur = start.resolve()
     while True:
         candidate = cur / PROJECT_DIRNAME / PROJECT_SUBDIRNAME
@@ -55,7 +55,7 @@ def resolve_scope(
         if not pdir:
             raise RuntimeError(
                 "No project scope found. "
-                "Run `geno-notes init --project` here first, or walk into a dir with ./geno/geno-notes/."
+                "Run `geno-notes init --project` here first, or walk into a dir with ./.geno/geno-notes/."
             )
         return Scope("project", pdir)
 


### PR DESCRIPTION
## Summary
- Changed `PROJECT_DIRNAME` from `"geno"` to `".geno"` so project scope lives at `.geno/geno-notes/`, consistent with the global scope at `~/.geno/geno-notes/`
- Replaced hardcoded `"geno"` path literals in `cli.py` `init` command with `PROJECT_DIRNAME` / `PROJECT_SUBDIRNAME` constants
- Updated docstrings and error messages to reflect the new path

## Test plan
- [x] `geno-notes init --project` creates `.geno/geno-notes/` (not `geno/geno-notes/`)
- [x] `geno-notes scope` correctly detects the project scope via ancestor walk
- [x] Delete and re-init produces the correct directory