### PR TITLE
Add geno-notes-sites-generate sub-skillset skill

### DIFF
--- a/GENO.md
+++ b/GENO.md
@@ -7,6 +7,7 @@ Project journal for AI coding agents: tasks, timestamped journal entries, plans.
 | Skill | Sub-skillset | Slash command |
 |-------|-------------|---------------|
 | geno-notes | — | — (umbrella) |
+| geno-notes-sites-generate | sites | /geno-notes-sites-generate |
 
 ## Repo structure
 
@@ -16,7 +17,9 @@ geno-notes/
 ├── SKILL.md             # umbrella skill manifest
 ├── genotools.yaml       # geno-tools manifest
 ├── skills/
-│   └── geno-notes/      #   umbrella skill
+│   ├── geno-notes/                #   umbrella skill
+│   │   └── SKILL.md
+│   └── geno-notes-sites-generate/ #   sub-skill: generate MkDocs site
 │       └── SKILL.md
 ├── commands/
 │   └── gt-notes.md      #   slash command dispatcher
@@ -39,8 +42,8 @@ geno-notes/
 
 ## Conventions
 
-- geno-notes is a single-skill skillset backed by a Python CLI. Subcommands are dispatched via the CLI, not separate skill folders.
-- The slash command `/gt-notes` dispatches to the `geno-notes` CLI binary.
+- Sub-skillsets have their own `skills/{name}/SKILL.md` and dispatch to the `geno-notes` CLI.
+- The umbrella slash command `/gt-notes` dispatches to the `geno-notes` CLI binary.
 
 ## Architecture
 

--- a/skills/geno-notes-sites-generate/SKILL.md
+++ b/skills/geno-notes-sites-generate/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: geno-notes-sites-generate
+description: >-
+  Generate a MkDocs Material website from geno-notes content.
+  Builds tasks, journal entries, wiki pages, and plans into a browsable
+  static site. Use when user says /geno-notes-sites-generate, wants to
+  build or preview a site from their notes, or deploy their journal as a website.
+argument-hint: "[--serve] [--open] [--port PORT] [--all] [--global|--project]"
+allowed-tools: "Bash(geno-notes *) Bash(~/.local/bin/geno-notes *) Bash(~/.geno/venv/bin/geno-notes *)"
+license: MIT
+metadata:
+  author: 42euge
+  version: "0.1.0"
+---
+
+# Generate Site
+
+Generate a MkDocs Material website from the notes in the active scope. The site is built to `.geno-notes/_site_staging/site/` (never checked in).
+
+## Input
+
+`$ARGUMENTS` are passed as flags to `geno-notes site`.
+
+## Options
+
+| Flag | Effect |
+|------|--------|
+| `--open` | Build and open the site in the default browser |
+| `--serve` | Start `mkdocs serve` for live-reloading preview |
+| `--port PORT` | Port for serve mode (default 8000) |
+| `--all` | Merge project + global scopes into one site |
+| `--global` | Force global scope |
+| `--project` | Force project scope |
+
+Default behavior (no flags): build, then ask the user if they want to open.
+
+## Examples
+
+```bash
+geno-notes site --open
+geno-notes site --serve --all
+geno-notes site --serve --port 3000 --project
+```
+
+## What it builds
+
+The site generator stages content from the active scope(s) into a temporary MkDocs project:
+
+- **Tasks** — grouped by status (active, backlog, done, abandoned)
+- **Journal** — monthly entries rendered as timeline pages
+- **Wiki** — compiled topic pages with wikilinks
+- **Plans** — task-linked planning documents
+
+## Dependencies
+
+Requires `mkdocs` and `mkdocs-material`. The CLI will prompt to install them if missing.


### PR DESCRIPTION
## Summary

- Adds `skills/geno-notes-sites-generate/SKILL.md` — the first sub-skillset skill for geno-notes, following the `{skillset}-{sub-skillset}-{skill}` nomenclature convention
- Updates `GENO.md`: skills table, repo structure tree, removes the "single-skill skillset" declaration
- Wraps the existing `geno-notes site` CLI command — no Python changes needed

## Context

geno-notes was declared as a "single-skill skillset" with 18 CLI subcommands in one umbrella skill. This violates the ecosystem sub-skillset convention that geno-audit enforces. This PR starts the migration by extracting site generation into its own skill.

## Test plan

- [ ] `/geno-notes-sites-generate --serve` starts a live-reloading preview
- [ ] `/geno-notes-sites-generate --open` builds and opens the site
- [ ] `/gt-notes site --open` still works via the umbrella