### PR TITLE
Add Obsidian vault generator sub-skillset

### DIFF
--- a/GENO.md
+++ b/GENO.md
@@ -10,6 +10,7 @@ Project journal for AI coding agents: tasks, timestamped journal entries, plans.
 | geno-notes-wiki-compile | wiki | /geno-notes-wiki-compile |
 | geno-notes-wiki-lint | wiki | /geno-notes-wiki-lint |
 | geno-notes-sites-generate | sites | /geno-notes-sites-generate |
+| geno-notes-vault-generate | vault | /geno-notes-vault-generate |
 
 ## Repo structure
 
@@ -25,7 +26,9 @@ geno-notes/
 │   │   └── SKILL.md
 │   ├── geno-notes-wiki-lint/       #   sub-skill: lint wiki health
 │   │   └── SKILL.md
-│   └── geno-notes-sites-generate/  #   sub-skill: generate MkDocs site
+│   ├── geno-notes-sites-generate/  #   sub-skill: generate MkDocs site
+│   │   └── SKILL.md
+│   └── geno-notes-vault-generate/  #   sub-skill: generate Obsidian vault
 │       └── SKILL.md
 ├── commands/
 │   └── gt-notes.md      #   slash command dispatcher

--- a/geno_notes/cli.py
+++ b/geno_notes/cli.py
@@ -466,6 +466,37 @@ def lint_cmd(global_: bool, project_: bool):
     _dump_sources(scope)
 
 
+# ─── vault (Obsidian) ─────────────────────────────────────────────────
+
+
+@main.command()
+@click.option("--open", "do_open", is_flag=True, help="Open the vault in Obsidian.")
+@click.option("--all", "union", is_flag=True, help="Merge project + global into one vault.")
+@_scope_options
+def vault(do_open: bool, union: bool, global_: bool, project_: bool):
+    """Generate an Obsidian vault from notes."""
+    from geno_notes import vault as vault_mod
+
+    if union:
+        scopes = list_all_scopes()
+    else:
+        scopes = [_pick_scope(global_, project_)]
+
+    if not scopes:
+        click.echo("error: no scopes found", err=True)
+        sys.exit(1)
+
+    click.echo(f"Generating vault from {len(scopes)} scope(s)…")
+    vault_dir = vault_mod.generate(scopes)
+    click.echo(f"Vault ready → {vault_dir}")
+
+    if do_open:
+        vault_mod.open_vault(vault_dir)
+    elif not do_open:
+        if click.confirm("Open in Obsidian?"):
+            vault_mod.open_vault(vault_dir)
+
+
 # ─── site ─────────────────────────────────────────────────────────────
 
 

--- a/geno_notes/vault.py
+++ b/geno_notes/vault.py
@@ -1,0 +1,253 @@
+"""Generate an Obsidian vault from geno-notes content."""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+from pathlib import Path
+
+from geno_notes import tasks
+from geno_notes.paths import Scope
+
+STAGING_DIR_NAME = "_vault_staging"
+
+
+def _stage_scope(scope: Scope, vault_dir: Path) -> None:
+    """Copy a scope's content into the vault directory, adapting for Obsidian."""
+    src = scope.dir
+
+    for section in ("tasks", "journal", "plans", "wiki"):
+        section_src = src / section
+        if not section_src.is_dir():
+            continue
+        section_dst = vault_dir / section.capitalize()
+        section_dst.mkdir(parents=True, exist_ok=True)
+        for item in sorted(section_src.rglob("*")):
+            if not item.is_file():
+                continue
+            if item.suffix == ".jsonl" or item.name == "README.md":
+                continue
+            rel = item.relative_to(section_src)
+            dst = section_dst / rel
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            if not dst.exists():
+                shutil.copy2(item, dst)
+
+    for fname in ("inbox.md",):
+        f = src / fname
+        if f.exists():
+            dst = vault_dir / fname.replace("inbox", "Inbox")
+            if not dst.exists():
+                shutil.copy2(f, dst)
+
+
+def _task_status_icon(status: str) -> str:
+    return {"active": "🔵", "backlog": "⚪", "done": "✅", "abandoned": "❌"}.get(
+        status, "⚪"
+    )
+
+
+def _build_home(vault_dir: Path, scopes: list[Scope]) -> None:
+    """Create the Home MOC (Map of Content) as the vault's landing page."""
+    lines = ["# geno-notes", ""]
+
+    all_tasks: list[tasks.Task] = []
+    for scope in scopes:
+        all_tasks.extend(tasks.load_all(scope.dir))
+
+    active = [t for t in all_tasks if t.status == "active"]
+    backlog = [t for t in all_tasks if t.status == "backlog"]
+    done = [t for t in all_tasks if t.status == "done"]
+
+    if active:
+        lines.append("## Active tasks")
+        lines.append("")
+        for t in active:
+            lines.append(f"- {_task_status_icon(t.status)} [[Tasks/{t.id}|{t.title}]]")
+        lines.append("")
+
+    lines.append(f"## Navigation")
+    lines.append("")
+    lines.append(f"- [[Tasks/_index|Tasks]] ({len(active)} active, {len(backlog)} backlog, {len(done)} done)")
+
+    journal_dir = vault_dir / "Journal"
+    if journal_dir.is_dir():
+        months = sorted(journal_dir.rglob("*.md"), reverse=True)
+        count = len(months)
+        lines.append(f"- Journal ({count} months)")
+        for m in months[:6]:
+            rel = m.relative_to(vault_dir)
+            label = m.stem
+            lines.append(f"  - [[{rel.with_suffix('')}|{label}]]")
+        if count > 6:
+            lines.append(f"  - _…and {count - 6} more_")
+
+    wiki_dir = vault_dir / "Wiki"
+    if wiki_dir.is_dir():
+        pages = [p for p in sorted(wiki_dir.glob("*.md")) if p.name not in ("index.md", "README.md")]
+        lines.append(f"- [[Wiki/index|Wiki]] ({len(pages)} pages)")
+        for p in pages[:10]:
+            label = p.stem.replace("-", " ").replace("_", " ").title()
+            lines.append(f"  - [[Wiki/{p.stem}|{label}]]")
+
+    plans_dir = vault_dir / "Plans"
+    if plans_dir.is_dir():
+        plans = sorted(plans_dir.glob("*.md"))
+        if plans:
+            lines.append(f"- Plans ({len(plans)})")
+            for p in plans:
+                label = p.stem.replace("-", " ").replace("_", " ")
+                lines.append(f"  - [[Plans/{p.stem}|{label}]]")
+
+    inbox = vault_dir / "Inbox.md"
+    if inbox.exists():
+        lines.append("- [[Inbox]]")
+
+    lines.append("")
+    (vault_dir / "Home.md").write_text("\n".join(lines), encoding="utf-8")
+
+
+def _build_task_index(vault_dir: Path, scopes: list[Scope]) -> None:
+    """Create the Tasks overview MOC."""
+    tasks_dir = vault_dir / "Tasks"
+    if not tasks_dir.is_dir():
+        return
+
+    all_tasks: list[tasks.Task] = []
+    for scope in scopes:
+        all_tasks.extend(tasks.load_all(scope.dir))
+
+    groups = {"active": [], "backlog": [], "done": [], "abandoned": []}
+    for t in all_tasks:
+        groups.setdefault(t.status, []).append(t)
+
+    lines = ["# Tasks", ""]
+    for status in ("active", "backlog", "done", "abandoned"):
+        items = groups.get(status, [])
+        if not items:
+            continue
+        lines.append(f"## {status.capitalize()} ({len(items)})")
+        lines.append("")
+        for t in items:
+            icon = _task_status_icon(status)
+            tags = " ".join(f"#{tag}" for tag in t.tags) if t.tags else ""
+            suffix = f"  {tags}" if tags else ""
+            lines.append(f"- {icon} [[{t.id}|{t.title}]]{suffix}")
+        lines.append("")
+
+    (tasks_dir / "_index.md").write_text("\n".join(lines), encoding="utf-8")
+
+
+def _write_obsidian_config(vault_dir: Path) -> None:
+    """Write minimal .obsidian/ config for a pleasant default experience."""
+    obsidian_dir = vault_dir / ".obsidian"
+    obsidian_dir.mkdir(exist_ok=True)
+
+    app_json = {
+        "defaultViewMode": "preview",
+        "showLineNumber": True,
+        "strictLineBreaks": True,
+        "readableLineLength": True,
+    }
+    (obsidian_dir / "app.json").write_text(
+        json.dumps(app_json, indent=2), encoding="utf-8"
+    )
+
+    appearance_json = {
+        "accentColor": "#7b6cf6",
+        "baseFontSize": 16,
+    }
+    (obsidian_dir / "appearance.json").write_text(
+        json.dumps(appearance_json, indent=2), encoding="utf-8"
+    )
+
+    workspace_json = {
+        "main": {
+            "id": "main",
+            "type": "split",
+            "children": [
+                {
+                    "id": "leaf-1",
+                    "type": "leaf",
+                    "state": {
+                        "type": "markdown",
+                        "state": {"file": "Home.md", "mode": "preview"},
+                    },
+                }
+            ],
+            "direction": "vertical",
+        },
+        "left": {"id": "left", "type": "split", "children": [], "direction": "horizontal", "width": 300},
+        "right": {"id": "right", "type": "split", "children": [], "direction": "horizontal", "width": 300},
+        "active": "leaf-1",
+    }
+    (obsidian_dir / "workspace.json").write_text(
+        json.dumps(workspace_json, indent=2), encoding="utf-8"
+    )
+
+    graph_json = {
+        "collapse-filter": False,
+        "search": "",
+        "showTags": True,
+        "showAttachments": False,
+        "hideUnresolved": False,
+        "showOrphans": True,
+        "collapse-color-groups": False,
+        "colorGroups": [
+            {"query": "path:Tasks", "color": {"a": 1, "rgb": 5145582}},
+            {"query": "path:Journal", "color": {"a": 1, "rgb": 2271478}},
+            {"query": "path:Wiki", "color": {"a": 1, "rgb": 16744448}},
+            {"query": "path:Plans", "color": {"a": 1, "rgb": 10066329}},
+        ],
+        "collapse-display": False,
+        "showArrow": True,
+        "textFadeMultiplier": 0,
+        "nodeSizeMultiplier": 1,
+        "lineSizeMultiplier": 1,
+        "collapse-forces": True,
+        "centerStrength": 0.5,
+        "repelStrength": 10,
+        "linkStrength": 1,
+        "linkDistance": 250,
+    }
+    (obsidian_dir / "graph.json").write_text(
+        json.dumps(graph_json, indent=2), encoding="utf-8"
+    )
+
+
+def generate(scopes: list[Scope], output_base: Path | None = None) -> Path:
+    """Create an Obsidian vault from one or more scopes. Returns the vault dir."""
+    primary = scopes[0]
+
+    if output_base is None:
+        output_base = primary.dir / ".geno-notes"
+    vault_dir = output_base / STAGING_DIR_NAME
+    if vault_dir.exists():
+        shutil.rmtree(vault_dir)
+    vault_dir.mkdir(parents=True)
+
+    for scope in scopes:
+        _stage_scope(scope, vault_dir)
+
+    _build_task_index(vault_dir, scopes)
+    _build_home(vault_dir, scopes)
+    _write_obsidian_config(vault_dir)
+
+    return vault_dir
+
+
+def open_vault(vault_dir: Path) -> None:
+    """Open the vault in Obsidian."""
+    import platform
+    import subprocess as sp
+
+    system = platform.system()
+    vault_uri = f"obsidian://open?path={vault_dir.resolve()}"
+
+    if system == "Darwin":
+        sp.Popen(["open", vault_uri])
+    elif system == "Linux":
+        sp.Popen(["xdg-open", vault_uri])
+    else:
+        print(f"Open Obsidian and add vault at: {vault_dir}")

--- a/skills/geno-notes-vault-generate/SKILL.md
+++ b/skills/geno-notes-vault-generate/SKILL.md
@@ -6,8 +6,8 @@ description: >-
   Obsidian vault with graph view, MOCs, and wikilinks. Use when user says
   /geno-notes-vault-generate, wants to open their notes in Obsidian, or
   export their journal as an Obsidian vault.
-argument-hint: "[--open] [--all] [--global|--project]"
-allowed-tools: "Bash(geno-notes *) Bash(~/.local/bin/geno-notes *) Bash(~/.geno/venv/bin/geno-notes *)"
+argument-hint: "[--all] [--global|--project]"
+allowed-tools: "Bash(geno-notes *) Bash(~/.local/bin/geno-notes *) Bash(~/.geno/venv/bin/geno-notes *) Bash(open *)"
 license: MIT
 metadata:
   author: 42euge
@@ -26,20 +26,17 @@ Generate an Obsidian vault from the notes in the active scope. The vault is crea
 
 | Flag | Effect |
 |------|--------|
-| `--open` | Build and open the vault in Obsidian |
 | `--all` | Merge project + global scopes into one vault |
 | `--global` | Force global scope |
 | `--project` | Force project scope |
 
-Default behavior (no flags): build, then ask the user if they want to open in Obsidian.
+## Workflow
 
-## Examples
-
-```bash
-geno-notes vault --open
-geno-notes vault --all
-geno-notes vault --open --project
-```
+1. Run `geno-notes vault` with any scope flags from `$ARGUMENTS`. Pipe `n` to stdin to skip the interactive prompt: `echo n | geno-notes vault [flags]`
+2. Capture the vault path from the "Vault ready →" output line.
+3. Report what was generated — number of tasks, journal months, wiki pages, plans staged.
+4. Ask the user if they'd like to open the vault in Obsidian.
+5. If yes, open it: `open "obsidian://open?path=<vault-path>"`
 
 ## What it builds
 
@@ -60,6 +57,10 @@ The vault generator stages content from the active scope(s) into an Obsidian-rea
 - **Tags** — task tags rendered as `#tag` for Obsidian tag search
 - **MOCs** — Home and Tasks index pages for navigation
 
-## Dependencies
+## Examples
 
-Requires Obsidian to be installed for `--open`. The vault itself is plain markdown — no build step needed.
+```bash
+geno-notes vault
+geno-notes vault --all
+geno-notes vault --project
+```

--- a/skills/geno-notes-vault-generate/SKILL.md
+++ b/skills/geno-notes-vault-generate/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: geno-notes-vault-generate
+description: >-
+  Generate an Obsidian vault from geno-notes content.
+  Builds tasks, journal entries, wiki pages, and plans into a browsable
+  Obsidian vault with graph view, MOCs, and wikilinks. Use when user says
+  /geno-notes-vault-generate, wants to open their notes in Obsidian, or
+  export their journal as an Obsidian vault.
+argument-hint: "[--open] [--all] [--global|--project]"
+allowed-tools: "Bash(geno-notes *) Bash(~/.local/bin/geno-notes *) Bash(~/.geno/venv/bin/geno-notes *)"
+license: MIT
+metadata:
+  author: 42euge
+  version: "0.1.0"
+---
+
+# Generate Obsidian Vault
+
+Generate an Obsidian vault from the notes in the active scope. The vault is created at `.geno-notes/_vault_staging/` (never checked in).
+
+## Input
+
+`$ARGUMENTS` are passed as flags to `geno-notes vault`.
+
+## Options
+
+| Flag | Effect |
+|------|--------|
+| `--open` | Build and open the vault in Obsidian |
+| `--all` | Merge project + global scopes into one vault |
+| `--global` | Force global scope |
+| `--project` | Force project scope |
+
+Default behavior (no flags): build, then ask the user if they want to open in Obsidian.
+
+## Examples
+
+```bash
+geno-notes vault --open
+geno-notes vault --all
+geno-notes vault --open --project
+```
+
+## What it builds
+
+The vault generator stages content from the active scope(s) into an Obsidian-ready directory:
+
+- **Home.md** — Map of Content (MOC) linking to all sections
+- **Tasks/** — one file per task with frontmatter, plus `_index.md` MOC grouped by status
+- **Journal/** — monthly entries preserving the `YYYY/YYYY-MM.md` structure
+- **Wiki/** — compiled topic pages with native `[[wikilinks]]`
+- **Plans/** — task-linked planning documents
+- **Inbox.md** — quick captures
+- **.obsidian/** — vault config with graph view color groups, workspace defaults
+
+## Obsidian features
+
+- **Graph view** — color-coded by section (Tasks=purple, Journal=teal, Wiki=orange, Plans=gray)
+- **Wikilinks** — `[[page]]` links work natively (geno-notes already uses this format)
+- **Tags** — task tags rendered as `#tag` for Obsidian tag search
+- **MOCs** — Home and Tasks index pages for navigation
+
+## Dependencies
+
+Requires Obsidian to be installed for `--open`. The vault itself is plain markdown — no build step needed.


### PR DESCRIPTION
## Summary

- Adds `geno-notes vault` CLI command and `geno_notes/vault.py` module that generates an Obsidian vault from geno-notes content
- Creates `geno-notes-vault-generate` sub-skillset (`/geno-notes-vault-generate` slash command)
- Mirrors `sites-generate` but for Obsidian: no build step, MOC-based navigation, `.obsidian/` config with graph view color groups, native `[[wikilinks]]` and `#tag` support

## Test plan

- [x] `geno-notes vault --help` prints usage
- [x] `geno-notes vault --global` generates vault at `.geno-notes/_vault_staging/`
- [x] Generated vault contains `Home.md`, `Tasks/_index.md`, `.obsidian/` config
- [ ] `geno-notes vault --open` opens vault in Obsidian
- [ ] Vault renders correctly in Obsidian with graph view and wikilink navigation