### PR TITLE
Add Three Pillars knowledge integration

### DIFF
--- a/geno_notes/cli.py
+++ b/geno_notes/cli.py
@@ -449,7 +449,17 @@ def context(
         if "wiki_last_compiled" in config_text:
             for line in config_text.splitlines():
                 if line.startswith("wiki_last_compiled"):
-                    bundle["wiki_last_compiled"] = line.split("=", 1)[1].strip().strip('"')
+                    ts_str = line.split("=", 1)[1].strip().strip('"')
+                    bundle["wiki_last_compiled"] = ts_str
+                    try:
+                        from datetime import datetime, timezone
+                        compiled_dt = datetime.fromisoformat(ts_str)
+                        if compiled_dt.tzinfo is None:
+                            compiled_dt = compiled_dt.replace(tzinfo=timezone.utc)
+                        age_days = (datetime.now(timezone.utc) - compiled_dt).days
+                        bundle["wiki_stale"] = age_days > 7
+                    except (ValueError, TypeError):
+                        bundle["wiki_stale"] = True
                     break
 
     # Output
@@ -473,6 +483,9 @@ def context(
         click.echo(f"\n## Wiki pages ({len(wiki_pages)} relevant)")
         for w in wiki_pages:
             click.echo(f"  [{w['scope']}] {w['slug']}")
+        if bundle.get("wiki_last_compiled"):
+            stale_marker = " (stale)" if bundle.get("wiki_stale") else ""
+            click.echo(f"\n## Wiki: last compiled {bundle['wiki_last_compiled']}{stale_marker}")
         if bundle.get("skill_health"):
             h = bundle["skill_health"]
             s = h.get("stats", {})

--- a/geno_notes/indexer.py
+++ b/geno_notes/indexer.py
@@ -7,6 +7,7 @@ available as `geno-notes reindex`.
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 
 from geno_notes import tasks as tasks_mod
@@ -19,6 +20,7 @@ def reindex(scope_dir: Path, scope_name: str) -> None:
         all_tasks = tasks_mod.load_all(scope_dir)
         _write_tasks_index(scope_dir, all_tasks)
         _write_root_index(scope_dir, scope_name, all_tasks)
+        _write_knowledge_index(scope_dir)
 
 
 def _write_tasks_index(scope_dir: Path, all_tasks: list[tasks_mod.Task]) -> None:
@@ -102,3 +104,43 @@ def _tail_events(scope_dir: Path, n: int = 10) -> list[dict]:
         except json.JSONDecodeError:
             continue
     return out
+
+
+def _write_knowledge_index(scope_dir: Path) -> None:
+    """Scan skill-knowledge/{patterns,decisions,errata} and write knowledge-index.jsonl."""
+    sk_dir = scope_dir / "skill-knowledge"
+    if not sk_dir.is_dir():
+        return
+
+    entries: list[dict] = []
+    for category in ("patterns", "decisions", "errata"):
+        cat_dir = sk_dir / category
+        if not cat_dir.is_dir():
+            continue
+        for f in sorted(cat_dir.glob("*.md")):
+            content = f.read_text(encoding="utf-8")
+            tags: list[str] = []
+            # Extract tags from YAML frontmatter if present
+            if content.startswith("---"):
+                end = content.find("---", 3)
+                if end != -1:
+                    for line in content[3:end].splitlines():
+                        stripped = line.strip()
+                        if stripped.startswith("tags:"):
+                            raw = stripped[5:].strip().strip("[]")
+                            tags = [t.strip().strip("\"'") for t in raw.split(",") if t.strip()]
+            stat = f.stat()
+            entries.append({
+                "type": category,
+                "id": f.stem,
+                "path": str(f.relative_to(scope_dir)),
+                "tags": tags,
+                "updated": datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat(),
+            })
+
+    out_path = scope_dir / ".geno-notes" / "knowledge-index.jsonl"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(
+        "\n".join(json.dumps(e) for e in entries) + ("\n" if entries else ""),
+        encoding="utf-8",
+    )

--- a/skills/geno-notes-sites-generate/SKILL.md
+++ b/skills/geno-notes-sites-generate/SKILL.md
@@ -54,3 +54,15 @@ The site generator stages content from the active scope(s) into a temporary MkDo
 ## Dependencies
 
 Requires `mkdocs` and `mkdocs-material`. The CLI will prompt to install them if missing.
+
+## Completion
+
+When this skill finishes, emit a trace:
+
+```bash
+geno-trace emit \
+  --skill geno-notes-sites-generate \
+  --status <success|failure|abandoned> \
+  --tool-calls <approximate count> \
+  --errors <count of tool/command errors>
+```

--- a/skills/geno-notes-vault-generate/SKILL.md
+++ b/skills/geno-notes-vault-generate/SKILL.md
@@ -64,3 +64,15 @@ geno-notes vault
 geno-notes vault --all
 geno-notes vault --project
 ```
+
+## Completion
+
+When this skill finishes, emit a trace:
+
+```bash
+geno-trace emit \
+  --skill geno-notes-vault-generate \
+  --status <success|failure|abandoned> \
+  --tool-calls <approximate count> \
+  --errors <count of tool/command errors>
+```

--- a/skills/geno-notes-wiki-compile/SKILL.md
+++ b/skills/geno-notes-wiki-compile/SKILL.md
@@ -57,3 +57,15 @@ geno-notes compile
 geno-notes compile --global
 geno-notes compile --project
 ```
+
+## Completion
+
+When this skill finishes, emit a trace:
+
+```bash
+geno-trace emit \
+  --skill geno-notes-wiki-compile \
+  --status <success|failure|abandoned> \
+  --tool-calls <approximate count> \
+  --errors <count of tool/command errors>
+```

--- a/skills/geno-notes-wiki-lint/SKILL.md
+++ b/skills/geno-notes-wiki-lint/SKILL.md
@@ -49,3 +49,15 @@ geno-notes lint
 geno-notes lint --global
 geno-notes lint --project
 ```
+
+## Completion
+
+When this skill finishes, emit a trace:
+
+```bash
+geno-trace emit \
+  --skill geno-notes-wiki-lint \
+  --status <success|failure|abandoned> \
+  --tool-calls <approximate count> \
+  --errors <count of tool/command errors>
+```


### PR DESCRIPTION
## Summary

- Extend `indexer.py` to generate `knowledge-index.jsonl` from `skill-knowledge/` directories
- Add `wiki_stale` flag to `geno-notes context` command (stale if wiki >7 days old)
- Add trace completion sections to 4 skills: wiki-compile, wiki-lint, sites-generate, vault-generate

## Test plan

- [ ] Run `geno-notes reindex` and verify `knowledge-index.jsonl` is created
- [ ] Run `geno-notes context --skill test` and verify `wiki_stale` flag appears
- [ ] Verify syntax: `python3 -c "import ast; ast.parse(open('geno_notes/indexer.py').read())"`